### PR TITLE
Update examples on create if needed

### DIFF
--- a/src/models/history/CaseAssembly.ts
+++ b/src/models/history/CaseAssembly.ts
@@ -1,3 +1,4 @@
+import { BuerliCadFacade } from '@buerli.io/classcad'
 import arrayBuffer from '../../resources/history/CaseAssembly.ofb?buffer'
 import { Create, Param, ParamType, Update } from '../../store'
 
@@ -22,6 +23,8 @@ export const create: Create = async (model, params) => {
   deltaX = (params.values[0] - 10) / 2
   deltaY = (params.values[1] - 10) / 2
   deltaZ = params.values[2] + 2.5
+
+  await updateExpressions(params.values[0], params.values[1], params.values[2], model)
 
   await assemblyApi.instance([
     {
@@ -72,7 +75,7 @@ export const create: Create = async (model, params) => {
 }
 
 export const update: Update = async (model, productId, params) => {
-  const { part: partApi, assembly: assemblyApi } = model.api.v1
+  const { assembly: assemblyApi } = model.api.v1
 
   if (Array.isArray(productId)) {
     throw new Error('Calling update does not support multiple product ids. Use a single product id only.')
@@ -83,38 +86,7 @@ export const update: Update = async (model, productId, params) => {
 
   // Update case and cover expressions
   if (check(paramsMap[0]) || check(paramsMap[1]) || check(paramsMap[2])) {
-    await partApi.updateExpression([
-      {
-        id: 'Case',
-        toUpdate: [
-          {
-            name: 'width',
-            value: params.values[0],
-          },
-          {
-            name: 'height',
-            value: params.values[1],
-          },
-          {
-            name: 'depth',
-            value: params.values[2],
-          },
-        ],
-      },
-      {
-        id: 'Cover',
-        toUpdate: [
-          {
-            name: 'width',
-            value: params.values[0],
-          },
-          {
-            name: 'height',
-            value: params.values[1],
-          },
-        ],
-      },
-    ])
+    await updateExpressions(params.values[0], params.values[1], params.values[2], model)
   }
 
   // Update transformation of screw instances
@@ -161,6 +133,26 @@ export const update: Update = async (model, productId, params) => {
   }
 
   return productId
+}
+
+const updateExpressions = async (width: number, height: number, depth: number, model: BuerliCadFacade) => {
+  await model.api.v1.part.updateExpression([
+    {
+      id: 'Case',
+      toUpdate: [
+        { name: 'width', value: width },
+        { name: 'height', value: height },
+        { name: 'depth', value: depth },
+      ],
+    },
+    {
+      id: 'Cover',
+      toUpdate: [
+        { name: 'width', value: width },
+        { name: 'height', value: height },
+      ],
+    },
+  ])
 }
 
 export default { create, update, paramsMap }

--- a/src/models/history/Robot6Axis_FC.ts
+++ b/src/models/history/Robot6Axis_FC.ts
@@ -85,6 +85,13 @@ export const create: Create = async (model, params) => {
     res = await assemblyApi.getFastened({ id: rootAsm, name: 'J5-J6' })
     const fcJ5 = res as FastenedConstraint
     constraints = [fcBase, fcJ1, fcJ2, fcJ3, fcJ4, fcJ5]
+    
+    // Update axis depending on current parameter values
+    for (let index = 0; index < 6; index++) {
+      if (params.values[index] !== paramsMap[index].value) {
+        await assemblyApi.updateFastened({ ...constraints[index], zRotation: (params.values[index] / 180) * Math.PI })
+      }
+    }
   }
 
   return rootAsm

--- a/src/models/history/SwissProperty.ts
+++ b/src/models/history/SwissProperty.ts
@@ -306,8 +306,17 @@ export const create: Create = async (model, params) => {
     activeExampleId = storeApi.getState().activeExample
     store.getState().setLayers(activeExampleId, -1, layers)
 
-    // Initial balkenwand configuration
-    await updateBalkenwandSize(params.values[wl], params.values[wh], params.values, layers, model)
+    // Initial settings
+    params.values[gt] !== paramsMap[gt].value && await updateLayer(params.values[gt], params.values, layers, 'Gipsplatte', model)
+    params.values[spt] !== paramsMap[spt].value && await updateLayer(params.values[spt], params.values, layers, 'Spanplatte', model)
+    params.values[dt] !== paramsMap[dt].value && await updateLayer(params.values[dt], params.values, layers, 'Daemmung', model)
+    params.values[hlt] !== paramsMap[hlt].value && await updateLayer(params.values[hlt], params.values, layers, 'Holzlattung', model)
+    params.values[hst] !== paramsMap[hst].value && await updateLayer(params.values[hst], params.values, layers, 'Holzschalung', model)
+    if (params.values[wl] !== paramsMap[wl].value || params.values[wh] !== paramsMap[wh].value) {
+      await updateWallSize(params.values[wl], params.values[wh], params.values, layers, model)
+      await updateBalkenwandSize(params.values[wl], params.values[wh], params.values, layers, model)
+    }
+    params.values[di] !== paramsMap[di].value && await explodeWall(params.values, layers, model)
   }
   return rootNode
 }

--- a/src/models/history/WirewayAssembly.ts
+++ b/src/models/history/WirewayAssembly.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines */
+import { BuerliCadFacade } from '@buerli.io/classcad'
 import templateSP from '../../resources/history/WirewayTemplate.ofb?buffer'
 import { Create, Param, ParamType, storeApi, Update } from '../../store'
 
@@ -29,20 +30,12 @@ const le = 0
 const he = 1
 const wi = 2
 const pd = 3
-const pa = 4
 
 export const paramsMap: Param[] = [
   { index: le, name: 'Length', type: ParamType.Slider, value: 200, step: 5, values: [100, 400] },
-  { index: he, name: 'Height', type: ParamType.Slider, value: 40, step: 5, values: [20, 80] },
-  { index: wi, name: 'Width', type: ParamType.Slider, value: 60, step: 5, values: [20, 120] },
+  { index: he, name: 'Height', type: ParamType.Slider, value: 30, step: 5, values: [20, 80] },
+  { index: wi, name: 'Width', type: ParamType.Slider, value: 30, step: 5, values: [20, 120] },
   { index: pd, name: 'Position', type: ParamType.Slider, value: 0, step: 5, values: [0, 100] },
-  {
-    index: pa,
-    name: 'Product Selection',
-    type: ParamType.Dropdown,
-    value: 'Select a product ...',
-    values: ['40x60', '60x80', '60x120'],
-  },
 ].sort((a, b) => a.index - b.index)
 
 let rootNode: number | null
@@ -78,81 +71,34 @@ export const create: Create = async (model, params) => {
     deckelPrt = (await assemblyApi.getPartTemplate({ name: 'Deckel' })) as number
     kanalPrt = (await assemblyApi.getPartTemplate({ name: 'Kanal' })) as number
     constrDeckel = (await assemblyApi.getFastened({ id: rootNode, name: 'Fastened' })) as FastenedConstraint
+    params.values[le] !== paramsMap[le].value && await updateLength(params.values[le], model)
+    params.values[wi] !== paramsMap[wi].value && await updateWidth(params.values[wi], model)
+    params.values[he] !== paramsMap[he].value && await updateHeight(params.values[he], model)
+    params.values[pd] !== paramsMap[pd].value &&
+      (await assemblyApi.updateFastened({ ...constrDeckel, zOffset: params.values[pd] }))
   }
   return rootNode
 }
 
 export const update: Update = async (model, productId, params) => {
-  const { part: partApi, assembly: assemblyApi } = model.api.v1
+  const { assembly: assemblyApi } = model.api.v1
 
   const updatedParamIndex = params.lastUpdatedParam
   const check = (param: Param) => typeof updatedParamIndex === 'undefined' || param.index === updatedParamIndex
-  const activeExample = storeApi.getState().activeExample
 
   // Update length
   if (check(paramsMap[le])) {
-    deckelPrt &&
-      kanalPrt &&
-      (await partApi.updateExpression([
-        {
-          id: deckelPrt,
-          toUpdate: [
-            {
-              name: 'Laenge',
-              value: params.values[le],
-            },
-          ],
-        },
-        {
-          id: kanalPrt,
-          toUpdate: [
-            {
-              name: 'Laenge',
-              value: params.values[le],
-            },
-          ],
-        },
-      ]))
+    await updateLength(params.values[le], model)
   }
 
   // Update height
   if (check(paramsMap[he])) {
-    kanalPrt &&
-      (await partApi.updateExpression({
-        id: kanalPrt,
-        toUpdate: [
-          {
-            name: 'Hoehe',
-            value: params.values[he],
-          },
-        ],
-      }))
+    await updateHeight(params.values[he], model)
   }
 
   // Update width
   if (check(paramsMap[wi])) {
-    deckelPrt &&
-      kanalPrt &&
-      (await partApi.updateExpression([
-        {
-          id: deckelPrt,
-          toUpdate: [
-            {
-              name: 'Breite',
-              value: params.values[wi] + 3,
-            },
-          ],
-        },
-        {
-          id: kanalPrt,
-          toUpdate: [
-            {
-              name: 'Breite',
-              value: params.values[wi],
-            },
-          ],
-        },
-      ]))
+    await updateWidth(params.values[wi], model)
   }
 
   // Update pos
@@ -160,29 +106,50 @@ export const update: Update = async (model, productId, params) => {
     await assemblyApi.updateFastened({ ...constrDeckel, zOffset: params.values[pd] })
   }
 
-  // Update produkt
-  if (check(paramsMap[pa])) {
-    switch (
-      params.values[pa] //'40x60', '60x80', '60x120'
-    ) {
-      case '40x60':
-        storeApi.getState().setParam(activeExample, he, 40)
-        storeApi.getState().setParam(activeExample, wi, 60)
-        break
-      case '60x80':
-        storeApi.getState().setParam(activeExample, he, 60)
-        storeApi.getState().setParam(activeExample, wi, 80)
-        break
-      case '60x120':
-        storeApi.getState().setParam(activeExample, he, 60)
-        storeApi.getState().setParam(activeExample, wi, 120)
-        break
-      default:
-        break
-    }
-  }
-
   return productId
+}
+
+const updateLength = async (length: number, model: BuerliCadFacade) => {
+  deckelPrt &&
+    kanalPrt &&
+    (await model.api.v1.part.updateExpression([
+      {
+        id: deckelPrt,
+        toUpdate: [{ name: 'Laenge', value: length }],
+      },
+      {
+        id: kanalPrt,
+        toUpdate: [{ name: 'Laenge', value: length }],
+      },
+    ]))
+}
+
+const updateWidth = async (width: number, model: BuerliCadFacade) => {
+  deckelPrt &&
+    kanalPrt &&
+    (await model.api.v1.part.updateExpression([
+      {
+        id: deckelPrt,
+        toUpdate: [{ name: 'Breite', value: width + 3 }],
+      },
+      {
+        id: kanalPrt,
+        toUpdate: [{ name: 'Breite', value: width }],
+      },
+    ]))
+}
+
+const updateHeight = async (height: number, model: BuerliCadFacade) => {
+  kanalPrt &&
+    (await model.api.v1.part.updateExpression({
+      id: kanalPrt,
+      toUpdate: [
+        {
+          name: 'Hoehe',
+          value: height,
+        },
+      ],
+    }))
 }
 
 export default { create, update, paramsMap }


### PR DESCRIPTION
When switching between examples, the model was sometimes different to the parameters. To have them synchronous we check the parameters already in the create method and update the model if needed.